### PR TITLE
Fix RNG seeding and denial-of-service

### DIFF
--- a/dice.go
+++ b/dice.go
@@ -50,6 +50,5 @@ func rollDice(code string) (*diceRolls, error) {
 }
 
 func rollDie(sides int) int {
-	rand.Seed(time.Now().UnixNano())
 	return 1 + rand.Intn(sides)
 }

--- a/dice.go
+++ b/dice.go
@@ -34,8 +34,8 @@ func rollDice(code string) (*diceRolls, error) {
 			return nil, fmt.Errorf("Could not parse a number of dice from '%s'", numberStr)
 		}
 		if number > 20 {
-			// Clamp it to sanity.
-			number = 20
+			// Complain about insanity.
+            return nil, fmt.Errorf("'%s' is way too many dice; maximum is 20.", numberStr)
 		}
 	}
 	sidesStr := submatches[0][3]
@@ -44,8 +44,8 @@ func rollDice(code string) (*diceRolls, error) {
 		return nil, fmt.Errorf("Could not parse a number of sides from '%s'", sidesStr)
 	}
 	if sides > 100 {
-		// Clamp it.
-		sides = 100
+		// Complain about insanity.
+        return nil, fmt.Errorf("'%s' is too many sides; maximum is 100.", sidesStr)
 	}
 
 	rolls := make([]int, number)

--- a/dice.go
+++ b/dice.go
@@ -35,7 +35,7 @@ func rollDice(code string) (*diceRolls, error) {
 		}
 		if number > 20 {
 			// Clamp it to sanity.
-			number := 20
+			number = 20
 		}
 	}
 	sidesStr := submatches[0][3]
@@ -45,7 +45,7 @@ func rollDice(code string) (*diceRolls, error) {
 	}
 	if sides > 100 {
 		// Clamp it.
-		sides := 100
+		sides = 100
 	}
 
 	rolls := make([]int, number)

--- a/dice.go
+++ b/dice.go
@@ -33,11 +33,19 @@ func rollDice(code string) (*diceRolls, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Could not parse a number of dice from '%s'", numberStr)
 		}
+		if number > 20 {
+			// Clamp it to sanity.
+			number := 20
+		}
 	}
 	sidesStr := submatches[0][3]
 	sides, err := strconv.Atoi(sidesStr)
 	if err != nil {
 		return nil, fmt.Errorf("Could not parse a number of sides from '%s'", sidesStr)
+	}
+	if sides > 100 {
+		// Clamp it.
+		sides := 100
 	}
 
 	rolls := make([]int, number)

--- a/dice.go
+++ b/dice.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"regexp"
 	"strconv"
-	"time"
 )
 
 type diceRolls struct {

--- a/dice_test.go
+++ b/dice_test.go
@@ -21,7 +21,7 @@ func TestRange1(t *testing.T) {
 	res, err := rollDice("1000d1")
 	assert.Nil(t, err)
 	assert.NotNil(t, res)
-	assert.Equal(t, 1000, len(res.results))
+	assert.Equal(t, 20, len(res.results))
 	for _, val := range res.results {
 		if val != 1 {
 			t.Errorf("Value '%d' is not valid for a D1 roll", val)
@@ -50,7 +50,7 @@ func Test50d1(t *testing.T) {
 	assert.NotNil(t, res)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, res.dieSides)
-	assert.Equal(t, 50, len(res.results))
+	assert.Equal(t, 20, len(res.results))
 }
 
 func Test1(t *testing.T) {

--- a/plugin.go
+++ b/plugin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+    "math/rand"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -177,5 +178,6 @@ func appError(message string, err error) *model.AppError {
 
 // Install the RCP plugin
 func main() {
+    rand.Seed(time.Now().UnixNano())
 	plugin.ClientMain(&DiceRollingPlugin{})
 }

--- a/plugin.go
+++ b/plugin.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-    "math/rand"
+	"math/rand"
 	"net/http"
 	"strings"
 	"sync/atomic"
-    "time"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/model"
@@ -179,6 +179,6 @@ func appError(message string, err error) *model.AppError {
 
 // Install the RCP plugin
 func main() {
-    rand.Seed(time.Now().UnixNano())
+	rand.Seed(time.Now().UnixNano())
 	plugin.ClientMain(&DiceRollingPlugin{})
 }

--- a/plugin.go
+++ b/plugin.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"sync/atomic"
+    "time"
 
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/model"


### PR DESCRIPTION
This should make it so the RNG is only seeded once per plugin instantiation, and prevent users from causing a denial-of-service by specifying huge number of rolls.